### PR TITLE
Create MYSQL_Create_customers_also_bought

### DIFF
--- a/MYSQL_Create_customers_also_bought
+++ b/MYSQL_Create_customers_also_bought
@@ -1,0 +1,7 @@
+CREATE TABLE wp_customers_also_bought (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    product_id INT UNSIGNED NOT NULL,
+    also_bought_product_id INT UNSIGNED NOT NULL,
+    times_purchased INT UNSIGNED NOT NULL DEFAULT 1,
+    UNIQUE KEY product_relation (product_id, also_bought_product_id)  -- Ensure that each product pair is unique
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
A few points to note:

    Table Name: I've named the table wp_customers_also_bought, assuming that the WordPress table prefix is wp_. Adjust the prefix if your WordPress installation uses a different one.
    InnoDB: I'm using the InnoDB storage engine because it's generally more reliable and offers features like foreign key constraints. However, if your MySQL setup uses MyISAM or another engine, adjust as necessary.
    Unique Key: The UNIQUE KEY on product_id and also_bought_product_id ensures that there's only one entry for each pair of products. This means when you're updating the data, you can simply increase the times_purchased value for the existing entry rather than adding a new row for every purchase.